### PR TITLE
Update bootstrap.sh for macOS

### DIFF
--- a/macos/bootstrap.sh
+++ b/macos/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-brew install pygobject3 gtk4 adwaita-icon-theme libadwaita
+brew install python3 pygobject3 gtk4 adwaita-icon-theme libadwaita
 
 echo "Done"


### PR DESCRIPTION
The Homebrew python3 package is explicitly required