### PR TITLE
fix: Update build.sh for portable windows

### DIFF
--- a/windows/build.sh
+++ b/windows/build.sh
@@ -30,7 +30,7 @@ else
 	python3 -OO -m PyInstaller $APP-portable.spec
 	echo "Preparing app..."
 	version=$(cat ../VERSION)
-	mv dist/* ./$APP-$version-portable.exe
+	mv dist/* ./$APP-$version-$(uname -m)-portable.exe
 fi
 for exe in $APP*.exe; do
     echo $(sha256sum $exe) > $exe.sha256


### PR DESCRIPTION
Update script to include architecture in built file name for portable windows build