### PR TITLE
Remove compiler flags from build scripts

### DIFF
--- a/linux/build.sh
+++ b/linux/build.sh
@@ -7,7 +7,7 @@ if [ ! -d ../venv ]; then
 	python3 -m venv --system-site-packages venv
 	. venv/bin/activate
 	python3 -m pip install --upgrade pip
-	PYINSTALLER_COMPILE_BOOTLOADER=1 PYI_STATIC_ZLIB=1 python3 -m pip install -r ../requirements.txt
+	python3 -m pip install -r ../requirements.txt
 else
 	. ../venv/bin/activate
 fi

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -7,7 +7,7 @@ if [ ! -d ../venv ]; then
 	python3 -m venv --system-site-packages venv
 	. venv/bin/activate
 	python3 -m pip install --upgrade pip
-	PYINSTALLER_COMPILE_BOOTLOADER=1 PYI_STATIC_ZLIB=1 python3 -m pip install -r ../requirements.txt
+	python3 -m pip install -r ../requirements.txt
 else
 	. ../venv/bin/activate
 fi

--- a/windows/build.sh
+++ b/windows/build.sh
@@ -9,7 +9,7 @@ if [ ! -d ../venv ]; then
 	python3 -m venv --system-site-packages venv
 	. venv/bin/activate
 	python3 -m pip install --upgrade pip
-	PYINSTALLER_COMPILE_BOOTLOADER=1 PYI_STATIC_ZLIB=1 python3 -m pip install -r ../requirements.txt
+	python3 -m pip install -r ../requirements.txt
 else
 	. ../venv/bin/activate
 fi


### PR DESCRIPTION
Since we no longer build pyinstaller from source, there is no need to keep the compiler flags in the build scripts. Fixes https://github.com/zevlee/passphraser/issues/31