### PR TITLE
fix: Update bootstrap.sh

### DIFF
--- a/macos/bootstrap.sh
+++ b/macos/bootstrap.sh
@@ -1,1 +1,3 @@
+# Workaround for externally-managed-environment error
+python3 -m pip config --global set global.break-system-packages true
 brew install pygobject3 gtk4 adwaita-icon-theme libadwaita


### PR DESCRIPTION
Fix the externally-managed-environment error on macos-14 GitHub runner